### PR TITLE
Scala 2.10 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,9 @@ version <<= liftVersion apply { _ + "-" + "0.3-SNAPSHOT" }
 
 organization := "net.liftmodules"
 
-scalaVersion := "2.9.1"
+scalaVersion := "2.10.0"
 
-crossScalaVersions := Seq("2.9.2", "2.9.1-1", "2.9.1")
+crossScalaVersions := Seq("2.9.2", "2.9.1-1", "2.9.1", "2.10.0")
 
 resolvers += "CB Central Mirror" at "http://repo.cloudbees.com/content/groups/public"
 
@@ -20,12 +20,17 @@ libraryDependencies <++= (liftVersion) { liftVersion =>
   Seq(
     "net.liftweb" %% "lift-mongodb-record" % liftVersion % "compile",
     "ch.qos.logback" % "logback-classic" % "1.0.3" % "provided",
-    "org.scalatest" %% "scalatest" % "1.8" % "test",
+    "org.scalatest" %% "scalatest" % "1.9.1" % "test",
     "org.mindrot" % "jbcrypt" % "0.3m" % "compile"
   )
 }
 
-scalacOptions ++= Seq("-deprecation", "-unchecked")
+scalacOptions <<= scalaVersion map { sv: String =>
+  if (sv.startsWith("2.10."))
+    Seq("-deprecation", "-unchecked", "-feature", "-language:postfixOps")
+  else
+    Seq("-deprecation", "-unchecked")
+}
 
 libraryDependencies <++= liftVersion { v =>
   "net.liftweb" %% "lift-webkit" % v % "compile->default" ::

--- a/src/main/scala/net.liftmodules/mongoauth/MongoAuth.scala
+++ b/src/main/scala/net.liftmodules/mongoauth/MongoAuth.scala
@@ -102,7 +102,7 @@ object AuthUtil {
         case x => Full(x)
       }
     } catch {
-      case e => Failure(e.getMessage, Full(e), Empty)
+      case (e: Throwable) => Failure(e.getMessage, Full(e), Empty)
     }
   }
 


### PR DESCRIPTION
Hi,

 I've just added Scala 2.10 support. The changes are fix of a warnings and compilation problems with new Scala. I've checked that all tests are passed both for Scala 2.9.1 and 2.10.0.
## 

Regards,
Mike.
