### PR TITLE
Expose liftVersion to SBT's command line.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,9 +1,7 @@
 import sbt._
 import sbt.Keys._
 
-object LiftModuleBuild extends Build {
-
-  import BuildSettings._
+object LiftModuleBuild extends Build with BuildSettings {
 
   val project = Project("lift-mongoauth", file("."))
     .settings(basicSettings:_*)

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -1,7 +1,7 @@
 import sbt._
 import sbt.Keys._
 
-object BuildSettings {
+trait BuildSettings {
 
   val resolutionRepos = Seq(
     Resolver.sonatypeRepo("releases"),


### PR DESCRIPTION
There's a problem with [the Jenkins build at CloudBees](https://liftmodules.ci.cloudbees.com/job/Mongoauth%20Lift%20Module) in that it can't set the `liftVersion` on Mongoauth any more.   This is needed only to force an automatic publish of a 3.0-SNAPSHOT version of the module on updates to the source.

## Problem

The Jenkins build runs this command:

```bash
/bin/java -XX:MaxPermSize=384M  -Xmx512M -Xss2M \ 
  -Dsbt.log.noformat=true -jar  /private/liftmodules/sbt-launch-13.0.jar \ 
   ";set liftVersion := \"3.0-SNAPSHOT\"; ++2.10.0; clean; update; test; package; publish"
```
... to force a build against Lift 3.0-SNAPSHOT regardless of what the build configuration in Git says.

(Note to self: replace `++2.10.0;` with 2.11)

This fails because the SBT command line interface cannot set `liftVersion`:

```
<set>:1: error: not found: value liftVersion
liftVersion := "3.0-SNAPSHOT"
^
[error] Type error in expression
Build step 'Execute shell' marked build as failure
```
## Solution?

This PR provides one way around this, by exposing the `liftVersion` in _Build.scala_.

I've copied in @fmpwizard as he may have a view on this.
